### PR TITLE
Reverting query next task

### DIFF
--- a/src/lib/annotation/annotation_management.py
+++ b/src/lib/annotation/annotation_management.py
@@ -195,28 +195,6 @@ class Task(BaseTask):
         # self.query_task()
 
     @staticmethod
-    def get_next_task(project_id: int) -> Union[int, None]:
-        """
-        Get the next unlabeled task ID (not labeled and not skipped) to help the user 
-        to proceed to next task automatically.
-        Returns `None` if there is no more unlabeled task ID.
-        """
-
-        sql_query = """
-        SELECT id
-        FROM task
-        WHERE project_id = %s
-        and (is_labelled = False and skipped = False)
-        LIMIT 1;
-        """
-        sql_vars = [project_id]
-        task_id = db_fetchone(sql_query, conn, sql_vars)  # return tuple
-        if task_id is not None:
-            task_id = int(task_id[0])
-            log_info(f"Next task ID: {task_id})")
-            return task_id
-
-    @staticmethod
     def check_if_task_exists(image_name: str, project_id: int, dataset_id: int, conn=conn) -> bool:
         """Check if tasks exist in the Task table
 

--- a/src/lib/data_editor/data_labelling.py
+++ b/src/lib/data_editor/data_labelling.py
@@ -99,9 +99,15 @@ def editor(data_id: List = []):
         # reset the flag to prevent issues when refreshing
         session_state.show_next_unlabeled = False
         # automatically move the labeling interface to the next unlabeled task
-        next_task_id = Task.get_next_task(session_state.project.id)
-        if next_task_id:
-            session_state.data_labelling_table = [next_task_id]
+        unlabeled_task_ids = task_df.query(
+            "`Is Labelled` == False and Skipped == False")['id']
+        # only do this if there is still unlabeled task
+        if not unlabeled_task_ids.empty:
+            # must use `int` to change it from `numpy.int` dtypes
+            next_unlabeled_task_id = int(unlabeled_task_ids.values[0])
+            log_info(f"Proceeding to next task ID: {next_unlabeled_task_id}")
+            # set this to show the next task, must set it to a list as this is how the `data_table` returns
+            session_state.data_labelling_table = [next_unlabeled_task_id]
         else:
             log_info("All tasks labeled successfully for Project ID: "
                      f"{session_state.project.id}")


### PR DESCRIPTION
Changed the `get_next_task` from using SQL query to just using the DataFrame created earlier in the `data_labelling.py` script. I made a mistake earlier and I thought it would be more complicated this way...