### PR TITLE
New Feature: Add option to allow user to use existing annotations

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -25,7 +25,7 @@ if str(LIB_PATH) not in sys.path:
 
 # DEFINE Web APP page configuration
 layout = 'wide'
-st.set_page_config(page_title="Integrated Vision Inspection System",
+st.set_page_config(page_title="AI4WD-IVIS",
                    page_icon="resources/shrdc-logo_no-bg.png", layout=layout)
 
 # user-defined modules
@@ -161,7 +161,7 @@ def main():
     with st.sidebar.container():
         st.image("resources/MSF-logo.gif", use_column_width=True)
 
-        st.title("Integrated Vision Inspection System", anchor='title')
+        st.title("AI4WD-IVIS - Integrated Vision Inspection System", anchor='title')
         st.header(
             "(Integrated by Malaysian Smart Factory 4.0 Team at SHRDC)", anchor='heading')
         st.markdown("___")

--- a/src/lib/annotation/annotation_management.py
+++ b/src/lib/annotation/annotation_management.py
@@ -629,7 +629,7 @@ class BaseAnnotations:
             logger.error(f"{error}: Annotations already exist")
             return None
 
-    def submit_annotations(self, result: Dict, users_id: int) -> int:
+    def submit_annotations(self, result: Dict, users_id: int, conn=conn) -> int:
         """ Submit result for new annotations
 
         Args:

--- a/src/lib/annotation/annotation_management.py
+++ b/src/lib/annotation/annotation_management.py
@@ -143,13 +143,21 @@ class NewTask(BaseTask):
 
     # create new Task
     @staticmethod
-    def insert_new_task(image_name: str, project_id: int, dataset_id: int) -> int:
+    def insert_new_task(image_name: str, project_id: int,
+                        dataset_id: int, is_labelled: bool = False,
+                        skipped: bool = False) -> int:
+        """Insert task and returns the newly inserted task's ID returned 
+        from the database."""
         insert_new_task_SQL = """
                                 INSERT INTO public.task (
                                     name,
                                     project_id,
-                                    dataset_id)
+                                    dataset_id,
+                                    is_labelled,
+                                    skipped)
                                 VALUES (
+                                    %s,
+                                    %s,
                                     %s,
                                     %s,
                                     %s)
@@ -157,10 +165,10 @@ class NewTask(BaseTask):
 
                                 RETURNING id;
                                         """
-        insert_new_task_vars = [image_name, project_id, dataset_id]
+        insert_new_task_vars = [image_name, project_id,
+                                dataset_id, is_labelled, skipped]
         task_id = db_fetchone(insert_new_task_SQL, conn,
                               insert_new_task_vars).id
-
         return task_id
 
 
@@ -521,6 +529,27 @@ class Task(BaseTask):
                          f"{project_id} :)")
         return record
 
+    @staticmethod
+    def update_task(task_id: int, annotation_id: int, is_labelled: bool, skipped: bool):
+        # NOTE: Update 'task' table with annotation id and set is_labelled flag as True
+        update_task_SQL = """
+                            UPDATE
+                                public.task
+                            SET
+                                annotation_id = %s,
+                                is_labelled = %s,
+                                skipped = %s
+                            WHERE
+                                id = %s
+                            RETURNING is_labelled;
+                        """
+
+        update_task_vars = [annotation_id, is_labelled, skipped, task_id]
+        try:
+            db_fetchone(update_task_SQL, conn, update_task_vars)
+        except TypeError as e:
+            logger.error(f"{e}: Task update for Submit failed")
+
 
 class Result:
     def __init__(self, from_name, to_name, type, value) -> None:
@@ -569,7 +598,38 @@ class BaseAnnotations:
         self.result: List[Dict, Result] = []  # or Dict?
         self.predictions: List[Dict, Predictions] = None
 
-    def submit_annotations(self, result: Dict, users_id: int, conn=conn) -> int:
+    @staticmethod
+    def insert_annotation(result: Dict, users_id: int,
+                          project_id: int, task_id: int, conn=conn):
+        # TODO is it neccessary to have annotation type id?
+        insert_annotations_SQL = """
+                                    INSERT INTO public.annotations (
+                                        result,
+                                        project_id,
+                                        users_id,
+                                        task_id)
+                                    VALUES (
+                                        %s::JSONB[],
+                                        %s,
+                                        %s,
+                                        %s)
+                                    RETURNING id;
+                                """
+        # insert_annotations_vars = [json.dumps(
+        #     result), self.task.project_id, users_id, self.task.id]
+        result_serialised = [json.dumps(x) for x in result]
+        insert_annotations_vars = [result_serialised,
+                                   project_id, users_id, task_id]
+        try:
+            annotation_id = db_fetchone(
+                insert_annotations_SQL, conn, insert_annotations_vars)
+            return annotation_id
+        except psycopg2.Error as e:
+            error = e.pgcode
+            logger.error(f"{error}: Annotations already exist")
+            return None
+
+    def submit_annotations(self, result: Dict, users_id: int) -> int:
         """ Submit result for new annotations
 
         Args:
@@ -583,58 +643,17 @@ class BaseAnnotations:
         Returns:
             [type]: [description]
         """
-        logger.debug(f"Submitting results.......")
+        # logger.debug(f"Submitting results.......")
         # NOTE: Update class object: result + task
         self.result = result if result else None
         self.task.is_labelled = True
-        # TODO is it neccessary to have annotation type id?
-        insert_annotations_SQL = """
-                                    INSERT INTO public.annotations (
-                                        result,
-                                        project_id,
-                                        users_id,
-                                        task_id)
-                                    VALUES (
-                                        %s::JSONB[],
-                                        %s,
-                                        %s,
-                                        %s)
-                                    RETURNING id,result;
-                                """
-        # insert_annotations_vars = [json.dumps(
-        #     result), self.task.project_id, users_id, self.task.id]
-        result_serialised = [json.dumps(x) for x in result]
-        insert_annotations_vars = [result_serialised,
-                                   self.task.project_id, users_id, self.task.id]
-        try:
-            self.id, self.result = db_fetchone(
-                insert_annotations_SQL, conn, insert_annotations_vars)
-        except psycopg2.Error as e:
-            error = e.pgcode
-            logger.error(f"{error}: Annotations already exist")
 
-        # NOTE: Update 'task' table with annotation id and set is_labelled flag as True
-        update_task_SQL = """
-                            UPDATE
-                                public.task
-                            SET
-                                annotation_id = %s,
-                                is_labelled = True,
-                                skipped = False
-                            WHERE
-                                id = %s
-                            RETURNING is_labelled;
-                        """
+        self.id = self.insert_annotation(result, users_id,
+                                         self.task.project_id, self.task.id)
 
-        update_task_vars = [self.id, self.task.id]
+        self.task.update_task(self.task.id, self.id,
+                              is_labelled=True, skipped=False)
 
-        try:
-            self.task.is_labelled = db_fetchone(
-                update_task_SQL, conn, update_task_vars)
-        except TypeError as e:
-            logger.error(f"{e}: Task update for Submit failed")
-
-        # sleep(1)
         return self.result
 
     def update_annotations(self, result: Dict, users_id: int, conn=conn) -> tuple:

--- a/src/lib/core/utils/helper.py
+++ b/src/lib/core/utils/helper.py
@@ -217,6 +217,7 @@ def get_directory_name(name: str) -> str:
 
     e.g. ' Dummy dataset 1 ' -> 'dummy-dataset-1'
     """
+    # NOTE: this function is directly related to the Project.query_annotations()
     directory_name = join_string(split_string(
         remove_newline_trailing_whitespace(str(name)))).lower()
     # replace symbols that are unwanted in file/folder names

--- a/src/lib/core/utils/helper.py
+++ b/src/lib/core/utils/helper.py
@@ -533,15 +533,13 @@ def list_available_cameras(num_check_ports: int):
     """
     # https://stackoverflow.com/questions/57577445/list-available-cameras-opencv-python
 
-    dev_port = 0
     working_ports = []
     available_ports = []
-    while True:
+    # check one extra port because port starts from 0
+    for dev_port in range(num_check_ports + 1):
         cap = cv2.VideoCapture(dev_port)
         if not cap.isOpened():
             logger.info(f"Port {dev_port} is not working.")
-            if dev_port >= int(num_check_ports):
-                break
         is_reading, img = cap.read()
         w = cap.get(3)
         h = cap.get(4)
@@ -557,7 +555,6 @@ def list_available_cameras(num_check_ports: int):
                         "but does not reads.")
             available_ports.append(dev_port)
         cap.release()
-        dev_port += 1
     return available_ports, working_ports
 
 

--- a/src/lib/core/utils/helper.py
+++ b/src/lib/core/utils/helper.py
@@ -21,6 +21,7 @@ import numpy as np
 import pytz
 import cv2
 import pandas as pd
+from psutil import virtual_memory, cpu_percent
 import streamlit as st
 
 from colorutils import hex_to_hsv
@@ -102,6 +103,19 @@ class Timer:
         """Stop the context manager timer"""
         if not self._disabled:
             self.stop()
+
+
+def get_ram_usage():
+    """Return the current RAM usage in percentage."""
+    return virtual_memory().percent
+
+
+def get_cpu_usage(interval: float = 4):
+    """Get CPU utilization over a specified interval.
+
+    NOTE: this function is a blocking operation, e.g. interval=4 will
+    block for 4 seconds to calculate CPU usage over time"""
+    return cpu_percent(interval)
 
 
 class HSV(NamedTuple):

--- a/src/lib/core/utils/log.py
+++ b/src/lib/core/utils/log.py
@@ -4,8 +4,11 @@ Date: 5/7/2021
 Author: Chu Zhen Hao
 Organisation: Malaysian Smart Factory 4.0 Team at Selangor Human Resource Development Centre (SHRDC)
 """
+from datetime import datetime
 import logging
 import os
+from pathlib import Path
+from natsort import os_sorted
 
 # environment variable should always be string
 if os.getenv('DEBUG', '1') == '1':
@@ -15,15 +18,37 @@ if os.getenv('DEBUG', '1') == '1':
 else:
     FORMAT = '[%(levelname)s] %(asctime)s - %(message)s'
     LEVEL = logging.INFO
-DATEFMT = '%d-%b-%y %H:%M:%S'
-LOG_FILE = 'test.log'
+
+LOG_FILE_DATEFMT = '%Y-%m-%d_%H-%M-%S_%f'
+LOG_START_TIME = datetime.now().strftime(LOG_FILE_DATEFMT)
+# Linux: /home/<username>/vision_system_logs
+# Windows: C:/Users/<username>/vision_system_logs
+LOG_DIR = Path.home() / 'vision_system_logs'
+LOG_FILE = LOG_DIR / f'logs_{LOG_START_TIME}.txt'
+if not LOG_DIR.exists():
+    os.makedirs(LOG_DIR)
+
+# change this accordingly
+MAX_LOGFILES_TO_KEEP = 1
+existing_logfiles = list(LOG_DIR.iterdir())
+total_logfiles = len(existing_logfiles)
+if total_logfiles > MAX_LOGFILES_TO_KEEP:
+    sorted_logfiles = os_sorted(existing_logfiles)
+
+    total_to_del = total_logfiles - MAX_LOGFILES_TO_KEEP
+    for i, fpath in enumerate(sorted_logfiles, start=1):
+        # print(f"Deleting old logfile: {fpath}")
+        fpath.unlink()
+        if i == total_to_del:
+            break
 
 # create logger
 logger = logging.getLogger(__name__)
-# set log level for all handlers to debug
+# set log level for all handlers
 logger.setLevel(LEVEL)
 
 # create formatter
+DATEFMT = '%d-%b-%y %H:%M:%S'
 formatter = logging.Formatter(FORMAT, datefmt=DATEFMT)
 
 # create console handler and setup level & formatter
@@ -33,10 +58,11 @@ consoleHandler.setFormatter(formatter)
 logger.addHandler(consoleHandler)
 
 # create file handler and setup for logger
-# fileHandler = logging.FileHandler(LOG_FILE)
-# fileHandler.setLevel(LEVEL)
-# fileHandler.setFormatter(formatter)
-# logger.addHandler(fileHandler)
+print(f"[INFO] Logging console outputs to {LOG_FILE}")
+fileHandler = logging.FileHandler(str(LOG_FILE))
+fileHandler.setLevel(LEVEL)
+fileHandler.setFormatter(formatter)
+logger.addHandler(fileHandler)
 
 # must set this to False to make sure that child logger does not propagate
 #  its message to the root logger

--- a/src/lib/core/utils/log.py
+++ b/src/lib/core/utils/log.py
@@ -29,7 +29,7 @@ if not LOG_DIR.exists():
     os.makedirs(LOG_DIR)
 
 # change this accordingly
-MAX_LOGFILES_TO_KEEP = 1
+MAX_LOGFILES_TO_KEEP = 10
 existing_logfiles = list(LOG_DIR.iterdir())
 total_logfiles = len(existing_logfiles)
 if total_logfiles > MAX_LOGFILES_TO_KEEP:

--- a/src/lib/core/utils/log.py
+++ b/src/lib/core/utils/log.py
@@ -6,6 +6,7 @@ Organisation: Malaysian Smart Factory 4.0 Team at Selangor Human Resource Develo
 """
 from datetime import datetime
 import logging
+from logging.handlers import RotatingFileHandler
 import os
 from pathlib import Path
 from natsort import os_sorted
@@ -59,7 +60,8 @@ logger.addHandler(consoleHandler)
 
 # create file handler and setup for logger
 print(f"[INFO] Logging console outputs to {LOG_FILE}")
-fileHandler = logging.FileHandler(str(LOG_FILE))
+fileHandler = RotatingFileHandler(
+    str(LOG_FILE), maxBytes=300_000, backupCount=5)
 fileHandler.setLevel(LEVEL)
 fileHandler.setFormatter(formatter)
 logger.addHandler(fileHandler)

--- a/src/lib/core/webcam/webcamvideostream.py
+++ b/src/lib/core/webcam/webcamvideostream.py
@@ -77,6 +77,8 @@ class WebcamVideoStream:
         if self.is_usb_camera:
             # cannot release for IP camera or error would occur
             self.stream.release()
+        # also reset the grabbed frame whenever stopped
+        self.frame = None
         self._stop_event.set()
         self.lock.release()
 

--- a/src/lib/core/webcam/webcamvideostream.py
+++ b/src/lib/core/webcam/webcamvideostream.py
@@ -1,0 +1,84 @@
+import cv2
+from threading import Thread, Lock, Event
+from time import sleep
+from typing import Union, Tuple
+
+
+class CameraFailError(Exception):
+    pass
+
+
+class WebcamVideoStream:
+    # based on https://github.com/xavialex/Streamlit-TF-Real-Time-Object-Detection/blob/master/video_utils.py
+    def __init__(
+            self, src: Union[int, str], shape: Tuple[int, int] = None,
+            is_usb_camera: bool = True, name: str = "WebcamVideoStream"):
+        """Initialize the video stream from a video
+
+        Args:
+            src (int | str): port or address of the camera to use.
+            name (str, default='WebcamVideoStream'): Name for the thread.
+            shape (Tuple[int, int]): set the resolution for the camera (might not work)
+            is_usb_camera (bool, default=True): whether it is a USB camera or other types of camera,
+                such as IP camera, to avoid issues when closing the camera.
+        Attributes:
+            name (str, default='WebcamVideoStream'): Name for the thread.
+            stream (cv2.VideoCapture): Webcam video stream.
+            grabbed (bool): Tells if the current frame's been correctly read.
+            frame (nparray): OpenCV image containing the current frame.
+            lock (_thread.lock): Lock to avoid race condition.
+            _stop_event (Event): Event used to gently stop the thread.
+        """
+        self.name = name
+        self.is_usb_camera = is_usb_camera
+        self.stream = cv2.VideoCapture(src)
+        if not self.stream.isOpened():
+            raise CameraFailError(f"Error opening camera from source: {src}")
+        else:
+            print(f"[INFO] Camera opened successfuly for src: {src}")
+        self.shape = shape
+        if self.shape is not None:
+            self.stream.set(3, shape[0])
+            self.stream.set(4, shape[1])
+        self.grabbed, self.frame = self.stream.read()
+        if not self.grabbed:
+            raise CameraFailError(f"Cannot grab frame from source: {src}")
+        else:
+            print("[INFO] Camera is reading frames")
+        self.lock = Lock()
+        self._stop_event = Event()
+
+    def start(self):
+        # Start the thread to read frames from the video stream
+        Thread(target=self.update, daemon=True,
+               name=self.name).start()
+        return self
+
+    def update(self):
+        # Continuosly iterate through the video stream until stopped
+        while self.stream.isOpened():
+            if not self.stopped():
+                self.grabbed, self.frame = self.stream.read()
+                # FPS = 60, i.e., 1 / 60 = 0.016667
+                sleep(0.0166)
+            else:
+                print(
+                    f"[INFO] The thread for reading the camera {self.name} is stopped")
+                return
+        print(
+            f"[INFO] The camera {self.name} is not opened anymore, stopping the thread now.")
+        self.stop()
+
+    def read(self):
+        return self.frame
+
+    def stop(self):
+        self.lock.acquire()
+        if self.is_usb_camera:
+            # cannot release for IP camera or error would occur
+            self.stream.release()
+        self._stop_event.set()
+        self.lock.release()
+
+    def stopped(self):
+        return self._stop_event.is_set()

--- a/src/lib/data_editor/data_labelling.py
+++ b/src/lib/data_editor/data_labelling.py
@@ -131,7 +131,7 @@ def editor(data_id: List[int] = None):
             # NOTE ************************TEST**************************************
             session_state.labelling_prev_result = []
             logger.info(
-                f"Task instantiated for id: {session_state.task.id} for {session_state.task.name}🏃")
+                f"Task instantiated for id: {session_state.task.id} for {session_state.task.name}")
         # >>>> INSTANTIATE TASK >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
             # Check if annotation exist

--- a/src/lib/data_editor/editor_management.py
+++ b/src/lib/data_editor/editor_management.py
@@ -515,7 +515,7 @@ class Editor(BaseEditor):
             return removedChild
 
     def update_editor_config(self):
-
+        """Update editor config based on self.xml_doc, also update database"""
         self.editor_config = self.to_xml_string(pretty=True)
         labels_json = self.convert_labels_dict_to_JSON()
 

--- a/src/lib/data_manager/annotation_type_select.py
+++ b/src/lib/data_manager/annotation_type_select.py
@@ -19,7 +19,7 @@ def annotation_sel():
     annotationType_list = (" ", "Image Classification", "Object Detection with Bounding Boxes",
                            "Semantic Segmentation with Polygons")
     annotationType_index = list(range(len(annotationType_list)))
-    annotationType = st.selectbox("Template", annotationType_list, index=0, format_func=lambda x: 'Select an option' if x == ' ' else x,
+    annotationType = st.selectbox("Deployment Type", annotationType_list, index=0, format_func=lambda x: 'Select an option' if x == ' ' else x,
                                   key="annotation_type", help="Please select the desired type of annotation")
     if annotationType != " ":
         annotationConfig_template = load_annotation_template(

--- a/src/lib/data_manager/dataset_management.py
+++ b/src/lib/data_manager/dataset_management.py
@@ -305,14 +305,18 @@ class BaseDataset:
             # just in case... to avoid errors
             all_img_names = set(all_img_names)
         error_img_paths = []
+        ori_img_names = []
+        new_img_names = []
 
         for img_path in stqdm(image_paths, unit=self.filetype, ascii='123456789#', st_container=st.sidebar, desc="Uploading images"):
             success, ori_img_name, new_img_name = save_single_image(
                 img_path, self.dataset_path,
                 all_img_names=all_img_names, verbose=verbose)
+            ori_img_names.append(ori_img_name)
+            new_img_names.append(new_img_name)
             if not success:
                 error_img_paths.append(img_path)
-        return error_img_paths
+        return ori_img_names, new_img_names, error_img_paths
 
     def calc_total_filesize(self):
         if self.dataset:
@@ -350,11 +354,12 @@ class BaseDataset:
 
     def save_dataset(
             self, archive_dir: Path,
-            save_images_to_disk: bool = True) -> Union[None, List[str]]:
+            save_images_to_disk: bool = True) -> Tuple[List[str], List[str], List[str]]:
         """`archive_dir` is the directory that contains the extracted tarfile contents
 
-        If `save_images_to_disk` is True, also returns `error_img_paths` (List[str]) 
-        for any images that were not saved successfully.
+        If `save_images_to_disk` is True, also returns Tuple of List[str] of
+        `ori_img_names`, `new_img_names` (new generated names saved in disk),
+        and `error_img_paths` for any images that were not saved successfully.
         """
 
         # Get absolute dataset folder path
@@ -364,9 +369,10 @@ class BaseDataset:
         if save_images_to_disk:
             existing_image_names = set(
                 self.get_image_paths(self.name, return_names=True))
-            error_img_paths = self.dataset_PNG_encoding(
+            ori_img_names, new_img_names, error_img_paths = self.dataset_PNG_encoding(
                 archive_dir, all_img_names=existing_image_names)
-            return error_img_paths
+            return ori_img_names, new_img_names, error_img_paths
+        return [], [], []
         # st.success(f"Successfully created **{self.name}** dataset")
 
     @staticmethod

--- a/src/lib/data_manager/dataset_management.py
+++ b/src/lib/data_manager/dataset_management.py
@@ -336,9 +336,16 @@ class BaseDataset:
         return dataset_path
 
     @staticmethod
-    def get_image_paths(dataset_name: str) -> List[str]:
+    def get_image_paths(
+            dataset_name: str, return_names: bool = False) -> List[str]:
+        """Get all the image paths from the dataset path. 
+
+        If `return_names` is True, return only the image filenames.
+        """
         dataset_path = BaseDataset.get_dataset_path(dataset_name)
         image_paths = list(list_images(dataset_path))
+        if return_names:
+            return [os.path.basename(p) for p in image_paths]
         return image_paths
 
     def save_dataset(
@@ -355,9 +362,8 @@ class BaseDataset:
 
         create_folder_if_not_exist(self.dataset_path)
         if save_images_to_disk:
-            existing_image_paths = self.get_image_paths(self.name)
             existing_image_names = set(
-                os.path.basename(p) for p in existing_image_paths)
+                self.get_image_paths(self.name, return_names=True))
             error_img_paths = self.dataset_PNG_encoding(
                 archive_dir, all_img_names=existing_image_names)
             return error_img_paths

--- a/src/lib/data_manager/dataset_management.py
+++ b/src/lib/data_manager/dataset_management.py
@@ -1173,15 +1173,19 @@ def save_single_image(img_path: str, dataset_path: Path,
     the image names exist within existing img_names or not to generate a new one
     if exists."""
     ori_img_name = os.path.basename(img_path)
-    new_img_name = f"{get_random_string(8)}_{ori_img_name}"
+    lowercase_ori_name = ori_img_name.lower()
+    # must compare with lowercase as filenames are usually case-insensitive in
+    # in most platforms, e.g. in Windows
+    allowed_chars = 'abcdefghijklmnopqrstuvwxyz0123456789'
+
+    def get_code():
+        return get_random_string(length=8, allowed_chars=allowed_chars)
+    new_img_name = f"{get_code()}_{lowercase_ori_name}"
     if all_img_names:
-        # must compare with lowercase as filenames are usually case-insensitive in
-        # in most platforms, e.g. in Windows
-        lowercase_name = new_img_name.lower()
-        while lowercase_name in all_img_names:
+        while new_img_name in all_img_names:
             # to ensure unique names
-            new_img_name = f"{get_random_string(8)}_{ori_img_name}"
-        all_img_names.add(lowercase_name)
+            new_img_name = f"{get_code()}_{lowercase_ori_name}"
+        all_img_names.add(new_img_name)
 
     save_path = dataset_path / new_img_name
     success = True

--- a/src/lib/deployment/deployment_management.py
+++ b/src/lib/deployment/deployment_management.py
@@ -135,7 +135,7 @@ class DeploymentConfig:
 
     # ip_cam_addresses: List[str] = field(default_factory=list)
     # for TFOD
-    confidence_threshold: float = 0.4
+    confidence_threshold: float = 0.7
     # for segmentation
     ignore_background: bool = False
 

--- a/src/lib/deployment/utils.py
+++ b/src/lib/deployment/utils.py
@@ -10,7 +10,8 @@ from pathlib import Path
 import streamlit as st
 import numpy as np
 from paho.mqtt.client import Client
-from imutils.video.webcamvideostream import WebcamVideoStream
+# from imutils.video.webcamvideostream import WebcamVideoStream
+from core.webcam.webcamvideostream import WebcamVideoStream
 from streamlit import session_state
 
 from core.utils.log import logger
@@ -182,13 +183,9 @@ def reset_csv_file_and_writer():
 
 
 def reset_camera():
-    for k in filter(lambda x: x.startswith('camera'), session_state.keys()):
-        cap = session_state[k]
+    for k, cap in filter(lambda x: x[0].startswith('camera'), session_state.items()):
         if isinstance(cap, WebcamVideoStream):
             cap.stop()
-            if 'ip' not in k:
-                # IP camera seems like have issues if try to release like this
-                cap.stream.release()
         elif isinstance(cap, cv2.VideoCapture):
             # cv2.VideoCapture instance
             cap.release()
@@ -202,10 +199,11 @@ def reset_camera_and_ports():
 
 
 def reset_record_and_vid_writer():
-    for k in filter(lambda x: x.startswith('vid_writer'), session_state.keys()):
-        if isinstance(session_state[k], cv2.VideoWriter):
+    for k, vid_writer in filter(lambda x: x[0].startswith('vid_writer'),
+                                session_state.items()):
+        if isinstance(vid_writer, cv2.VideoWriter):
             # must release to properly close the video file
-            session_state[k].release()
+            vid_writer.release()
         del session_state[k]
     if 'record' in session_state:
         del session_state['record']

--- a/src/lib/machine_learning/trainer.py
+++ b/src/lib/machine_learning/trainer.py
@@ -1262,7 +1262,15 @@ class Trainer:
                 train_ds, test_ds = self.create_tf_dataset(
                     X_train, y_train, X_test, y_test, keras_model=model)
 
-        # ***************** Preparing callbacks *****************
+        # ********* Preparing for training, including callbacks *********
+        if not is_resume:
+            initial_epoch = 0
+            num_epochs = self.training_param['num_epochs']
+        else:
+            initial_epoch = session_state.new_training.progress['Epoch']
+            logger.debug(f"{initial_epoch = }")
+            num_epochs = initial_epoch + self.training_param['num_epochs']
+
         progress_placeholder = {}
         progress_placeholder['epoch'] = st.empty()
         progress_placeholder['batch'] = st.empty()
@@ -1273,13 +1281,6 @@ class Trainer:
             num_epochs=num_epochs, update_metrics=update_metrics)
 
         # ********************** Train the model **********************
-        if not is_resume:
-            initial_epoch = 0
-            num_epochs = self.training_param['num_epochs']
-        else:
-            initial_epoch = session_state.new_training.progress['Epoch']
-            logger.debug(f"{initial_epoch = }")
-            num_epochs = initial_epoch + self.training_param['num_epochs']
         if self.has_valid_set:
             validation_data = val_ds
         else:

--- a/src/lib/machine_learning/trainer.py
+++ b/src/lib/machine_learning/trainer.py
@@ -1527,7 +1527,6 @@ class Trainer:
                 for i, (img_path, mask_path) in enumerate(zip(current_image_paths, current_labels)):
                     logger.debug(f"Image path: {img_path}")
                     filename = os.path.basename(img_path)
-                    logger.info(f)
 
                     image = cv2.imread(img_path)
                     orig_H, orig_W = image.shape[:2]

--- a/src/lib/machine_learning/visuals.py
+++ b/src/lib/machine_learning/visuals.py
@@ -34,7 +34,7 @@ def pretty_format_param(param_dict: Dict[str, Any], float_format: str = '.5g',
     Set them to False to display as one line, especially useful for table/dataframe.
     """
     config_info = []
-    for k, v in param_dict.items():
+    for k, v in sorted(param_dict.items()):
         if "_" in k:
             param_name = ' '.join(k.split('_')).capitalize()
         else:

--- a/src/lib/machine_learning/visuals.py
+++ b/src/lib/machine_learning/visuals.py
@@ -231,7 +231,8 @@ def draw_gt_bboxes(
     box_coordinates: Sequence[Tuple[int, int, int, int]],
     class_names: Union[List[str], str] = None,
     color: Tuple[int, int, int] = (0, 150, 0),
-    class_colors: Dict[str, Tuple[int, int, int]] = None
+    class_colors: Dict[str, Tuple[int, int, int]] = None,
+    copy_image: bool = True,
 ) -> np.ndarray:
     """Draw bounding boxes on the image and return the drawn image as a copy.
 
@@ -250,7 +251,8 @@ def draw_gt_bboxes(
     Returns:
         np.ndarray: the image drawn with bounding boxes
     """
-    image_with_gt_box = image_np.copy()
+    if copy_image:
+        image_np = image_np.copy()
     logger.debug(f"Total annotations for the image: {len(box_coordinates)}")
     logger.debug(f"{class_names = }")
 
@@ -269,7 +271,7 @@ def draw_gt_bboxes(
         if class_colors:
             color = class_colors[class_name]
         cv2.rectangle(
-            image_with_gt_box,
+            image_np,
             (xmin, ymin),
             (xmax, ymax),
             color=color,
@@ -282,7 +284,7 @@ def draw_gt_bboxes(
             )
 
             cv2.rectangle(
-                image_with_gt_box,
+                image_np,
                 (xmin - 1, y),
                 (
                     int(xmin + label_width * 1.02),
@@ -293,7 +295,7 @@ def draw_gt_bboxes(
             )
 
             cv2.putText(
-                image_with_gt_box,
+                image_np,
                 class_name,
                 (
                     int(xmin + label_width * 0.02),
@@ -304,7 +306,7 @@ def draw_gt_bboxes(
                 color=(255, 255, 255),
                 thickness=2,
             )
-    return image_with_gt_box
+    return image_np
 
 
 def draw_tfod_bboxes(

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -694,7 +694,8 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
                                     f"Average {time_elapsed / total_images:.4f}s per image")
 
                         with st.spinner("Updating project labels and editor configuration ..."):
-                            project.update_editor_config(is_new_project)
+                            project.update_editor_config(
+                                is_new_project, refresh_project=True)
 
                         if error_imgs:
                             with st.expander("""NOTE: These images were unreadable and

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -496,25 +496,6 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
             context, field_placeholder=place, name_key='name')
 
         if dataset.has_submitted:
-            # check for duplicated filenames
-            # NOTE: this is to avoid issues of replacing images of same name when
-            # moving/copying images
-            with st.spinner("Checking for duplicated filenames in the archive ..."):
-                image_names = [os.path.basename(p) for p in image_paths]
-                if len(set(image_names)) != len(image_names):
-                    txt = "Duplicated image filenames found!"
-                    logger.error(txt)
-                    st.error(txt)
-                    with st.spinner("Looking for duplicated filenames ..."):
-                        counts = Counter(image_names)
-                        duplicated_names = []
-                        for image_name, cnt in counts.items():
-                            if cnt > 1:
-                                duplicated_names.append(image_name)
-                    with st.expander("Duplicated filenames:"):
-                        st.markdown("  \n".join(duplicated_names))
-                    st.stop()
-
             if is_existing_dataset:
                 logger.info(
                     "Checking for duplicated filenames with existing dataset")
@@ -553,6 +534,25 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
                     with st.spinner("Checking uploaded images ..."):
                         logger.info("Checking uploaded images")
                         image_paths = check_image_files(filepaths)
+
+            # check for duplicated filenames
+            # NOTE: this is to avoid issues of replacing images of same name when
+            # moving/copying images
+            with st.spinner("Checking for duplicated filenames in the archive ..."):
+                image_names = [os.path.basename(p) for p in image_paths]
+                if len(set(image_names)) != len(image_names):
+                    txt = "Duplicated image filenames found!"
+                    logger.error(txt)
+                    st.error(txt)
+                    with st.spinner("Looking for duplicated filenames ..."):
+                        counts = Counter(image_names)
+                        duplicated_names = []
+                        for image_name, cnt in counts.items():
+                            if cnt > 1:
+                                duplicated_names.append(image_name)
+                    with st.expander("Duplicated filenames:"):
+                        st.markdown("  \n".join(duplicated_names))
+                    st.stop()
 
             dataset.dataset = image_paths
 

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -691,10 +691,16 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
 
         if error_imgs:
             if len(error_imgs) == total_images:
-                st.error("""All annotations were not saved successfully. 
-                Please check again for any errors with the images""")
+                st.error("""All annotations were not saved successfully. Please check
+                again for any errors with the images. Then please go back to project
+                creation page and try again.""")
                 dataset.delete_dataset(dataset.id)
                 project.delete_project(project.id)
+                NewProject.reset_new_project_page()
+                NewDataset.reset_new_dataset_page()
+                # also could be coming from project dashboard
+                Project.reset_dashboard_page()
+                session_state.project_pagination = ProjectPagination.Dashboard
                 st.stop()
             txt = """NOTE: These images were not found/unreadable and
                 thus skipped, but others are stored successfully in the

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -174,9 +174,13 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
 
     # >>>> CHECK IF NAME EXISTS CALLBACK >>>>
     def check_if_name_exist(field_placeholder, conn):
+        input_name = session_state.name.strip()
+        # NOTE: MUST BE LOWERCASE TO AVOID REPLACING EXISTING DIRECTORIES
+        # as directory name is case-insensitive
+        lower_input_name = input_name.lower()
         context = {'column_name': 'name',
-                   'value': session_state.name}
-        if session_state.name:
+                   'value': lower_input_name}
+        if lower_input_name:
             if dataset.check_if_exists(context, conn):
                 dataset.name = None
                 field_placeholder['name'].error(
@@ -184,7 +188,8 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
                 sleep(1)
                 logger.error(f"Dataset name used. Please enter a new name")
             else:
-                dataset.name = session_state.name
+                # save the user's input one but check with lowercase one
+                dataset.name = input_name
                 logger.info(f"Dataset name fresh and ready to rumble")
 
     # >>>>>>> DATASET INFORMATION >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -494,7 +499,11 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
         submit_button = button_place.button("Submit", key="submit")
 
     if submit_button:
-        context = {'name': dataset.name,
+        input_name = session_state.name.strip()
+        lower_input_name = input_name.lower()
+
+        # check lowercase name, but insert user input name later
+        context = {'name': lower_input_name,
                    'upload': session_state.upload_widget}
         if is_existing_dataset:
             # don't need to check for dataset name for existing dataset
@@ -504,6 +513,8 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
             context, field_placeholder=place, name_key='name')
         if not dataset.has_submitted:
             st.stop()
+        # save the user input name, not the lowercase one
+        dataset.name = input_name
 
         with outercol2:
             if session_state.is_labeled:

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -628,7 +628,6 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
             dataset.name, return_names=True))
         message = "Inserting uploaded annotations into database"
         for relative_img_path, result in stqdm(result_generator, total=total_images,
-                                               st_container=st.sidebar,
                                                unit=filetype, desc=message):
             # start_task = perf_counter()
             full_image_path = os.path.join(

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -613,7 +613,8 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
             classif_annot_type=classif_annot_type
         )
         # use this to keep track of existing task names (i.e. image names)
-        all_img_names = set()
+        all_img_names = set(dataset.get_image_paths(
+            dataset.name, return_names=True))
         message = "Inserting uploaded annotations into database"
         for relative_img_path, result in stqdm(result_generator, total=total_images,
                                                st_container=st.sidebar,

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -738,8 +738,8 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
                             NewDataset.reset_new_dataset_page()
                             # also could be coming from project dashboard
                             Project.reset_dashboard_page()
-                            project_pagination = ProjectPagination.Existing
-                            project_status = ProjectPagination.Existing
+                            session_state.project_pagination = ProjectPagination.Existing
+                            session_state.project_status = ProjectPagination.Existing
                             session_state.append_project_flag = ProjectPermission.ViewOnly
 
                             logger.info(

--- a/src/lib/pages/sub_pages/dataset_page/new_dataset.py
+++ b/src/lib/pages/sub_pages/dataset_page/new_dataset.py
@@ -59,10 +59,10 @@ from core.utils.helper import Timer, list_available_cameras
 from core.utils.file_handler import extract_archive, list_files_in_archived, check_image_files
 from core.utils.log import logger
 from data_manager.database_manager import init_connection
-from data_manager.dataset_management import NewDataset, get_dataset_name_list, get_latest_captured_image_path, query_dataset_list
+from data_manager.dataset_management import NewDataset, find_image_path, get_dataset_name_list, get_latest_captured_image_path, query_dataset_list, save_single_image
 from path_desc import TEMP_DIR, chdir_root
 from project.project_management import NewProject, Project, ProjectPagination, ProjectPermission
-from annotation.annotation_management import NewAnnotations, Task
+from annotation.annotation_management import Annotations, NewAnnotations, NewTask, Task
 from user.user_management import User
 from deployment.utils import reset_camera, reset_camera_and_ports
 
@@ -137,6 +137,13 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
         deployment_type = project.deployment_type
     elif 'new_project' in session_state:
         deployment_type = session_state.new_project.deployment_type
+
+    def clean_archive_dir():
+        # remove the unneeded extracted archive dir contents
+        with st.spinner("Removing the unwanted extracted files ..."):
+            shutil.rmtree(dataset.archive_dir)
+            logger.info(
+                "Removed temporary directory for extracted contents")
 
     if is_existing_dataset:
         # session_state.dataset_chosen should be obtained from existing_project_dashboard
@@ -399,14 +406,17 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
                 st.info(
                     "#### Compatible Annotation Format:  \n"
                     "- Object detection should have one XML file for each uploaded image.  \n"
+                    "**Filenames** should be **unique** for the best results.  \n"
                     "- Image classification can have two types:  \n"
                     "1. CSV file: should only have images and only one CSV file, "
                     "the first row of CSV file should be the filename with extension, while "
                     "the second row should be the class label name.  \n"
+                    "Note that the filenames **must be unique**.  \n"
                     "2. Label by folder names: Each image is labeled by the folder name they "
                     "reside in. E.g. *cat1.jpg* image is in a folder named as *cat*, this "
                     "image will be labeled as *cat*  \n"
-                    "- Image segmentation should only have images and only one COCO JSON file.  \n")
+                    "- Image segmentation should only have images and only one COCO JSON file.  \n"
+                    "**Filenames** should also be **unique** for the best results.")
 
         # default to CSV file for everything else
         classif_annot_type = 'CSV file'
@@ -483,8 +493,6 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
         button_place = st.empty()
         submit_button = button_place.button("Submit", key="submit")
 
-    # st.write(session_state)
-
     if submit_button:
         context = {'name': dataset.name,
                    'upload': session_state.upload_widget}
@@ -494,248 +502,231 @@ def new_dataset(RELEASE=True, conn=None, is_new_project: bool = True, is_existin
 
         dataset.has_submitted = dataset.check_if_field_empty(
             context, field_placeholder=place, name_key='name')
+        if not dataset.has_submitted:
+            st.stop()
 
-        if dataset.has_submitted:
-            if is_existing_dataset:
-                logger.info(
-                    "Checking for duplicated filenames with existing dataset")
-                with outercol2:
-                    with st.spinner("Checking for duplicated filenames with existing dataset ..."):
-                        uploaded_files = [
-                            os.path.basename(f) for f in filepaths]
-                        existing_images = project.data_name_list[
-                            session_state.dataset_chosen]
-                        duplicates = set(uploaded_files).intersection(
-                            existing_images)
-                    if duplicates:
-                        logger.error("Duplicated image filenames found")
-                        st.error("Found image filenames in the archive that are identical to "
-                                 "the current project dataset. Please make sure to use "
-                                 "different names to avoid overwriting existing images.")
-                        with st.expander("List of duplicates:"):
-                            st.markdown("  \n".join(duplicates))
-                        st.stop()
-
+        if is_existing_dataset:
+            logger.info(
+                "Checking for duplicated filenames with existing dataset")
             with outercol2:
-                if session_state.is_labeled:
-                    with st.spinner("Checking uploaded dataset and annotations ..."):
-                        logger.info(
-                            "Checking uploaded dataset and annotations")
-                        start = perf_counter()
-                        image_paths = dataset.validate_labeled_data(
-                            uploaded_archive, filepaths, deployment_type,
-                            classif_annot_type=classif_annot_type)
-                        time_elapsed = perf_counter() - start
-                        logger.info(
-                            f"Done. [{time_elapsed:.4f} seconds]")
-                        st.success("""🎉 Annotations are verified to be compatible and
-                        in the correct format.""")
-                else:
-                    with st.spinner("Checking uploaded images ..."):
-                        logger.info("Checking uploaded images")
-                        image_paths = check_image_files(filepaths)
-
-            # check for duplicated filenames
-            # NOTE: this is to avoid issues of replacing images of same name when
-            # moving/copying images
-            with st.spinner("Checking for duplicated filenames in the archive ..."):
-                image_names = [os.path.basename(p) for p in image_paths]
-                if len(set(image_names)) != len(image_names):
-                    txt = "Duplicated image filenames found!"
-                    logger.error(txt)
-                    st.error(txt)
-                    with st.spinner("Looking for duplicated filenames ..."):
-                        counts = Counter(image_names)
-                        duplicated_names = []
-                        for image_name, cnt in counts.items():
-                            if cnt > 1:
-                                duplicated_names.append(image_name)
-                    with st.expander("Duplicated filenames:"):
-                        st.markdown("  \n".join(duplicated_names))
+                with st.spinner("Checking for duplicated filenames with existing dataset ..."):
+                    uploaded_files = [
+                        os.path.basename(f) for f in filepaths]
+                    existing_images = project.data_name_list[
+                        session_state.dataset_chosen]
+                    duplicates = set(uploaded_files).intersection(
+                        existing_images)
+                if duplicates:
+                    logger.error("Duplicated image filenames found")
+                    st.error("Found image filenames in the archive that are identical to "
+                             "the current project dataset. Please make sure to use "
+                             "different names to avoid overwriting existing images.")
+                    with st.expander("List of duplicates:"):
+                        st.markdown("  \n".join(duplicates))
                     st.stop()
 
-            dataset.dataset = image_paths
-
-            # create a temporary directory for extracting the archive contents
-            if TEMP_DIR.exists():
-                shutil.rmtree(TEMP_DIR)
-            os.makedirs(TEMP_DIR)
-            dataset.archive_dir = TEMP_DIR
-
-            with outercol3:
-                with st.spinner("Extracting uploaded archive contents ..."):
-                    extract_archive(TEMP_DIR, file_object=uploaded_archive)
-
-            if dataset.save_dataset(dataset.archive_dir):
-
-                success_place.success(
-                    f"Successfully created **{dataset.name}** dataset")
-
-                if is_existing_dataset:
-                    dataset_func = dataset.update_dataset_size
-                else:
-                    dataset_func = dataset.insert_dataset
-
-                if dataset_func():
-
-                    success_place.success(
-                        f"Successfully stored **{dataset.name}** dataset information in database")
-
-                    if is_existing_dataset:
-                        # insert the new image info into the `task` table for existing dataset,
-                        # `os_sorted` is used to sort the files just like in file browser
-                        # to make the order of the files make more sense to the user
-                        # especially in the labelling pages ('data_labelling.py' & 'labelling_dashboard.py')
-                        image_names = [os.path.basename(p)
-                                       for p in os_sorted(image_paths)]
-                        project.insert_new_project_task(
-                            dataset.name,
-                            dataset.id,
-                            image_names=image_names)
-
-                    if session_state.is_labeled:
-                        # We need to insert the project_dataset here after the dataset
-                        # has been stored
-                        if not is_existing_dataset:
-                            # if not updating, then we insert the new project_dataset
-                            with st.spinner("Inserting the project dataset ..."):
-                                # similar to `new_project.py`
-                                existing_dataset, _ = query_dataset_list()
-                                dataset_dict = get_dataset_name_list(
-                                    existing_dataset)
-                                # add the uploaded dataset as the dataset_chosen, to
-                                # allow the insert_project_dataset to work
-                                dataset_name = dataset.name
-                                dataset_chosen = [dataset_name]
-                                project.insert_project_dataset(
-                                    dataset_chosen, dataset_dict)
-                                project_id = project.id
-                                logger.info(f"Inserted project dataset '{dataset_name}' for "
-                                            f"Project {project_id} into project_dataset table")
-                                # must refresh all the dataset details
-                                project.refresh_project_details()
-
-                        with st.spinner("Querying all the labeled images ..."):
-                            all_task, all_task_column_names = Task.query_all_task(
-                                project.id,
-                                return_dict=True,
-                                # using True to use 'id' instead of 'ID' for the first column name
-                                for_data_table=True)
-                            task_df = Task.create_all_task_dataframe(
-                                all_task, all_task_column_names)
-
-                            # taking only the filename without extension to consider the
-                            #  case of Label Studio exported XML filenames without
-                            #  any file extension
-                            if project.deployment_type == 'Object Detection with Bounding Boxes':
-                                task_df['Task Name'] = task_df['Task Name'].apply(
-                                    lambda filename: os.path.splitext(filename)[0])
-
-                        total_images = len(task_df)
-                        filetype = dataset.filetype
-                        logger.info("Submitting uploaded annotations ...")
-
-                        start_t = perf_counter()
-                        error_imgs = []
-                        # set this to False to check how long each process takes
-                        disable_timer = True
-
-                        result_generator = dataset.parse_annotation_files(
-                            project.deployment_type, image_paths,
-                            classif_annot_type=classif_annot_type
-                        )
-                        message = "Inserting uploaded annotations into database"
-                        for img_name, result in stqdm(result_generator, total=total_images,
-                                                      st_container=st.sidebar,
-                                                      unit=filetype, desc=message):
-                            # start_task = perf_counter()
-
-                            task_row = task_df.loc[
-                                task_df['Task Name'] == img_name
-                            ].to_dict(orient='records')
-
-                            if task_row:
-                                # index into the List of Dict of task
-                                task_row = task_row[0]
-                            else:
-                                logger.error(
-                                    f"Image '{img_name}' not found. Probably removed "
-                                    "because unable to read the image. Skipping from "
-                                    "submitting to database.")
-                                # these images were skipped in dataset_PNG_encoding()
-                                error_imgs.append(img_name)
-                                continue
-
-                            with Timer("Task instantiated", disable_timer):
-                                task = Task(task_row,
-                                            project.dataset_dict,
-                                            project.id,
-                                            generate_data_url=False)
-
-                            with Timer("Annotation instantiated", disable_timer):
-                                annotation = NewAnnotations(
-                                    task, session_state.user)
-
-                            # Submit annotations to DB
-                            with Timer(f"Annotation ID {annotation.id} submitted", disable_timer):
-                                annotation.submit_annotations(
-                                    result, session_state.user.id, conn)
-
-                            # time_elapsed = perf_counter() - start_task
-                            # logger.debug(
-                                # f"Annotation submitted successfully [{time_elapsed:.4f}s]")
-
-                        time_elapsed = perf_counter() - start_t
-                        st.success(
-                            "🎉 Successfully stored the uploaded annotations!")
-                        logger.info("Successfully inserted all annotations for "
-                                    f"{total_images} images into database. "
-                                    f"Took {time_elapsed:.2f} seconds. "
-                                    f"Average {time_elapsed / total_images:.4f}s per image")
-
-                        with st.spinner("Updating project labels and editor configuration ..."):
-                            project.update_editor_config(
-                                is_new_project, refresh_project=True)
-
-                        if error_imgs:
-                            with st.expander("""NOTE: These images were unreadable and
-                                skipped, but others are stored successfully in the
-                                database. You may now proceed to enter the current project."""):
-                                st.warning("  \n".join(error_imgs))
-                        else:
-                            st.success("""🎉 All images and annotations are successfully
-                            stored in database. You may now proceed to enter the current project.""")
-
-                        # clear out the "Submit" button to avoid further interactions
-                        button_place.empty()
-
-                        def enter_project_cb():
-                            NewProject.reset_new_project_page()
-                            NewDataset.reset_new_dataset_page()
-                            # also could be coming from project dashboard
-                            Project.reset_dashboard_page()
-                            session_state.project_pagination = ProjectPagination.Existing
-                            session_state.project_status = ProjectPagination.Existing
-                            session_state.append_project_flag = ProjectPermission.ViewOnly
-
-                            logger.info(
-                                f"Entering Project {project.id}")
-                            gc.collect()
-
-                        st.button("Enter Project", key="btn_enter_project",
-                                  on_click=enter_project_cb)
-                else:
-                    st.error(
-                        f"Failed to stored **{dataset.name}** dataset information in database")
+        with outercol2:
+            if session_state.is_labeled:
+                with st.spinner("Checking uploaded dataset and annotations ..."):
+                    logger.info(
+                        "Checking uploaded dataset and annotations")
+                    start = perf_counter()
+                    image_paths = dataset.validate_labeled_data(
+                        uploaded_archive, filepaths, deployment_type,
+                        classif_annot_type=classif_annot_type)
+                    time_elapsed = perf_counter() - start
+                    logger.info(
+                        f"Done. [{time_elapsed:.4f} seconds]")
+                    st.success("""🎉 Annotations are verified to be compatible and
+                    in the correct format.""")
             else:
-                st.error(
-                    f"Failed to created **{dataset.name}** dataset")
+                with st.spinner("Checking uploaded images ..."):
+                    logger.info("Checking uploaded images")
+                    image_paths = check_image_files(filepaths)
 
-            # remove the unneeded extracted archive dir contents
-            with st.spinner("Removing the unwanted extracted files ..."):
-                shutil.rmtree(dataset.archive_dir)
-                logger.info(
-                    "Removed temporary directory for extracted contents")
+        logger.info(f"Found {len(image_paths)} images in the archive.")
+        dataset.dataset = image_paths
+
+        # create a temporary directory for extracting the archive contents
+        if TEMP_DIR.exists():
+            shutil.rmtree(TEMP_DIR)
+        os.makedirs(TEMP_DIR)
+        dataset.archive_dir = TEMP_DIR
+
+        with outercol3:
+            with st.spinner("Extracting uploaded archive contents ..."):
+                extract_archive(TEMP_DIR, file_object=uploaded_archive)
+
+        success_place.success(
+            f"Successfully created **{dataset.name}** dataset")
+
+        if is_existing_dataset:
+            if dataset.update_dataset_size():
+                success_place.success(
+                    f"Successfully updated **{dataset.name}** dataset size information")
+        else:
+            if dataset.insert_dataset():
+                success_place.success(
+                    f"Successfully stored **{dataset.name}** dataset information in database")
+
+        # For labeled dataset, don't save the images to disk because it's
+        # easier to store together with annotations later
+        save_images_to_disk = False if session_state.is_labeled else True
+        error_img_paths = dataset.save_dataset(
+            dataset.archive_dir, save_images_to_disk=save_images_to_disk)
+        if error_img_paths:
+            st.error("Failed to save dataset")
+            with st.expander("The following images cannot be read:"):
+                st.markdown("\n  ".join(error_img_paths))
+            dataset.delete_dataset(dataset.id)
+            st.stop()
+
+        # NOTE: stop here if not uploading any labeled dataset
+        if not session_state.is_labeled:
+            txt = ("Successfully stored the new dataset in database "
+                   "and local storage.")
+            logger.info(txt)
+            st.success(txt)
+            clean_archive_dir()
+            st.stop()
+
+        # We need to insert the project_dataset here after the dataset
+        # has been stored
+        if not is_existing_dataset:
+            # if not updating, then we insert the new project_dataset
+            with st.spinner("Inserting the project dataset ..."):
+                # add the uploaded dataset as the dataset_chosen, to
+                # allow the insert_project_dataset to work
+                dataset_name = dataset.name
+                dataset_chosen = [dataset_name]
+                # skip inserting task to insert them later when submitting
+                # annotations
+                project.insert_project_dataset(
+                    dataset_chosen, insert_task=False)
+                logger.info(f"Inserted project dataset '{dataset_name}' for "
+                            f"Project {project.id} into project_dataset table")
+                # must refresh all the dataset details
+                project.refresh_project_details()
+
+        total_images = len(image_paths)
+        logger.info(
+            f"Found {total_images} images in the database.")
+        filetype = dataset.filetype
+        logger.info("Submitting uploaded annotations ...")
+
+        start_t = perf_counter()
+        error_imgs = []
+        result_generator = dataset.parse_annotation_files(
+            project.deployment_type,
+            image_paths=image_paths,
+            classif_annot_type=classif_annot_type
+        )
+        # use this to keep track of existing task names (i.e. image names)
+        all_img_names = set()
+        message = "Inserting uploaded annotations into database"
+        for relative_img_path, result in stqdm(result_generator, total=total_images,
+                                               st_container=st.sidebar,
+                                               unit=filetype, desc=message):
+            # start_task = perf_counter()
+            full_image_path = os.path.join(
+                dataset.archive_dir, relative_img_path)
+            if not os.path.exists(full_image_path):
+                error_txt = (
+                    f"Image '{relative_img_path}' not found. Maybe the image "
+                    "does not exist, or was removed "
+                    "because unable to read the image. Skipping from "
+                    "submitting to database.")
+                if deployment_type == 'Object Detection with Bounding Boxes':
+                    # check without file extension
+                    image_name = os.path.basename(
+                        os.path.splitext(relative_img_path)[0])
+                else:
+                    image_name = os.path.basename(relative_img_path)
+
+                # attempt to find the image path
+                image_fpath = find_image_path(
+                    image_paths, image_name, deployment_type)
+                if not image_fpath:
+                    logger.error(error_txt)
+                    error_imgs.append(relative_img_path)
+                    continue
+
+                full_image_path = os.path.join(
+                    dataset.archive_dir, image_fpath)
+                if not os.path.exists(full_image_path):
+                    logger.error(error_txt)
+                    error_imgs.append(relative_img_path)
+                    continue
+
+            success, ori_img_name, new_img_name = save_single_image(
+                full_image_path, dataset.dataset_path, all_img_names)
+            if not success:
+                txt = f"Unable to read or save the image for: {relative_img_path}"
+                logger.error(txt)
+                st.error(txt)
+                dataset.delete_dataset(dataset.id)
+                st.stop()
+
+            task_id = NewTask.insert_new_task(
+                new_img_name, project.id, dataset.id)
+            annot_id = Annotations.insert_annotation(
+                result, session_state.user.id,
+                project.id, task_id)
+            Task.update_task(task_id, annot_id,
+                             is_labelled=True, skipped=False)
+
+            # time_elapsed = perf_counter() - start_task
+            # logger.debug(
+            # f"Annotation submitted successfully [{time_elapsed:.4f}s]")
+
+        time_elapsed = perf_counter() - start_t
+        logger.info("Done inserting all annotations for "
+                    f"{total_images} images into database. "
+                    f"Took {time_elapsed:.2f} seconds. "
+                    f"Average {time_elapsed / total_images:.4f}s per image")
+
+        with st.spinner("Updating project labels and editor configuration ..."):
+            project.update_editor_config(
+                is_new_project, refresh_project=True)
+
+        if error_imgs:
+            if len(error_imgs) == total_images:
+                st.error("""All annotations were not saved successfully. 
+                Please check again for any errors with the images""")
+                dataset.delete_dataset(dataset.id)
+                project.delete_project(project.id)
+                st.stop()
+            txt = """NOTE: These images were not found/unreadable and
+                thus skipped, but others are stored successfully in the
+                database. You should check that the annotation file points 
+                to the correct image path. If you think it's safe to ignore, then 
+                you may now proceed to enter the current project."""
+            with st.expander(txt):
+                st.warning("  \n".join(error_imgs))
+        else:
+            st.success("""🎉 All images and annotations are successfully
+            stored in database. You may now proceed to enter the current project.""")
+
+        # clear out the "Submit" button to avoid further interactions
+        button_place.empty()
+
+        def enter_project_cb():
+            NewProject.reset_new_project_page()
+            NewDataset.reset_new_dataset_page()
+            # also could be coming from project dashboard
+            Project.reset_dashboard_page()
+            session_state.project_pagination = ProjectPagination.Existing
+            session_state.project_status = ProjectPagination.Existing
+            session_state.append_project_flag = ProjectPermission.ViewOnly
+
+            logger.info(
+                f"Entering Project {project.id}")
+            gc.collect()
+
+        st.button("Enter Project", key="btn_enter_project",
+                  on_click=enter_project_cb)
+
+        clean_archive_dir()
 
     # FOR DEBUGGING:
     # st.write("vars(dataset)")

--- a/src/lib/pages/sub_pages/deployment_page/deployment_page.py
+++ b/src/lib/pages/sub_pages/deployment_page/deployment_page.py
@@ -34,7 +34,8 @@ from time import perf_counter, sleep
 from itertools import cycle
 
 import cv2
-from imutils.video.webcamvideostream import WebcamVideoStream
+# from imutils.video.webcamvideostream import WebcamVideoStream
+from core.webcam.webcamvideostream import WebcamVideoStream
 from matplotlib import pyplot as plt
 import numpy as np
 from paho.mqtt.client import Client
@@ -220,16 +221,18 @@ def index(RELEASE=True):
                 # reset them in reset_camera()
                 cam_type = conf.camera_types[i]
                 if cam_type == 'USB Camera':
-                    cam_key = f'camera_{i}'
+                    is_usb_camera = True
                 else:
-                    # using a different key for IP camera to avoid release it
-                    # during reset_camera()
-                    cam_key = f'camera_ip_{i}'
+                    # set this for IP camera to avoid release it
+                    # during reset_camera() to avoid error
+                    is_usb_camera = False
+
+                cam_key = f'camera_{i}'
                 conf.camera_keys.append(cam_key)
 
                 try:
                     session_state[cam_key] = WebcamVideoStream(
-                        src=src).start()
+                        src=src, is_usb_camera=is_usb_camera, name=cam_key).start()
                     if session_state[cam_key].read() is None:
                         raise Exception(
                             "Video source is not valid")

--- a/src/lib/pages/sub_pages/deployment_page/deployment_page.py
+++ b/src/lib/pages/sub_pages/deployment_page/deployment_page.py
@@ -655,7 +655,7 @@ def index(RELEASE=True):
                                             else conf.num_cameras)
                         with st.form("form_num_cameras", clear_on_submit=True):
                             st.number_input(
-                                "Number of cameras", 2, 5, conf.num_cameras, 1,
+                                "Number of cameras", 2, 10, conf.num_cameras, 1,
                                 key='num_cameras')
                             st.form_submit_button(
                                 "Update number of cameras",

--- a/src/lib/pages/sub_pages/models_page/models_page.py
+++ b/src/lib/pages/sub_pages/models_page/models_page.py
@@ -385,11 +385,13 @@ def existing_models():
 
     # CALLBACK: CHECK IF MODEL NAME EXISTS
     def check_if_name_exist(field_placeholder, conn):
+        input_name = session_state.training_model_name.strip()
+        lower_input_name = input_name.lower()
         context = {'column_name': 'name',
-                   'value': session_state.training_model_name}
+                   'value': lower_input_name}
 
         with field_placeholder['training_model_name'].container():
-            if session_state.training_model_name:
+            if lower_input_name:
                 if training.training_model.check_if_exists(context, conn):
                     # training.training_model.name = ''
                     st.error("Model name used. Please enter a new name")
@@ -399,9 +401,10 @@ def existing_models():
                         f"Training Model name used. Please enter a new name")
                     st.stop()
                 else:
-                    # training.training_model.name = session_state.training_model_name
+                    # save the user's input one but check with lowercase one
+                    # training.training_model.name = input_name
                     logger.info("Training Model name fresh and ready to rumble: "
-                                f"'{session_state.training_model_name}'")
+                                f"'{input_name}'")
             else:
                 st.error("Please enter a model name!")
                 st.stop()
@@ -417,7 +420,7 @@ def existing_models():
                   )
     session_state.new_training_place['training_model_name'] = st.empty(
     )
-    # st.write(session_state.training_model_name)
+    # st.write(lower_input_name)
 
     # ************************* MODEL DESCRIPTION (OPTIONAL) *************************
     description = st.text_area(
@@ -440,9 +443,11 @@ def existing_models():
     # *************************************CALLBACK: NEXT BUTTON *************************************
     def to_training_configuration_page():
         # check_if_name_exist(session_state.new_training_place, conn)
+        input_name = session_state.training_model_name.strip()
+        lower_input_name = input_name.lower()
 
         if training.has_submitted[NewTrainingPagination.Model] and \
-                training.training_model.name == session_state.training_model_name:
+                training.training_model.name.lower() == lower_input_name:
             # no need to check whether the name exists if the user is using the same
             # existing submitted name
             logger.info("Existing model name is not changed")
@@ -453,8 +458,9 @@ def existing_models():
         new_training_model_submission_dict = NewTrainingSubmissionHandlers(
             insert=training.training_model.create_new_project_model_pipeline,
             update=training.training_model.update_new_project_model_pipeline,
+            # check the lowercase input name, but insert user input name later
             context={
-                'training_model_name': session_state.training_model_name,
+                'training_model_name': lower_input_name,
                 # 'attached_model_selection': session_state.existing_models_table
             },
             name_key=name_key
@@ -481,7 +487,8 @@ def existing_models():
                     project_name=session_state.project.name,
                     training_name=training.name,
                     training_id=training.id,
-                    new_model_name=session_state.training_model_name
+                    # insert/update the user input one, not the lowercase one
+                    new_model_name=input_name
             ):
                 if training.attached_model is not None and \
                         selected_model.name != training.attached_model.name:

--- a/src/lib/pages/sub_pages/project_page/existing_project.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project.py
@@ -105,6 +105,8 @@ def index():
 
     session_state.append_project_flag = ProjectPermission.ViewOnly
     # >>>> Pagination RADIO >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+    # note that this must follow the exact order of ExistingProjectPagination,
+    # check the callback function to understand why
     existing_project_page_options = (
         "Overview", "Labelling", "Training", "Deployment", "Settings")
 
@@ -112,9 +114,11 @@ def index():
     def existing_project_page_navigator():
 
         navigation_selected = session_state.existing_project_page_navigator_radio
-        navigation_selected_idx = existing_project_page_options.index(
+        session_state.existing_project_pagination = ExistingProjectPagination.from_string(
             navigation_selected)
-        session_state.existing_project_pagination = navigation_selected_idx
+        # navigation_selected_idx = existing_project_page_options.index(
+        #     navigation_selected)
+        # session_state.existing_project_pagination = navigation_selected_idx
 
         # NOTE: TO RESET SUB-PAGES AFTER EXIT
         # reset all pages except for the currently selected one
@@ -156,11 +160,22 @@ def index():
             Training.reset_training_page()
             Deployment.reset_deployment_page()
 
-    if session_state.project.datasets:
-        # only show this if project has already selected a dataset
-        with st.sidebar.expander("Project Navigation", expanded=True):
-            st.radio("Sections", options=existing_project_page_options,
-                     index=session_state.existing_project_pagination, on_change=existing_project_page_navigator, key="existing_project_page_navigator_radio")
+    if not session_state.project.datasets:
+        # only show overview and settings navigation (to allow project deletion)
+        available_options = ("Overview", "Settings")
+        if session_state.existing_project_pagination == ExistingProjectPagination.Dashboard:
+            idx = 0
+        else:
+            idx = 1
+    else:
+        available_options = existing_project_page_options
+        idx = session_state.existing_project_pagination
+    with st.sidebar.expander("Project Navigation", expanded=True):
+        st.radio(
+            "Sections", options=available_options,
+            index=idx,
+            on_change=existing_project_page_navigator,
+            key="existing_project_page_navigator_radio")
     st.sidebar.markdown("___")
     # >>>> Pagination RADIO >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 

--- a/src/lib/pages/sub_pages/project_page/existing_project.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project.py
@@ -114,11 +114,9 @@ def index():
     def existing_project_page_navigator():
 
         navigation_selected = session_state.existing_project_page_navigator_radio
-        session_state.existing_project_pagination = ExistingProjectPagination.from_string(
+        navigation_selected_idx = existing_project_page_options.index(
             navigation_selected)
-        # navigation_selected_idx = existing_project_page_options.index(
-        #     navigation_selected)
-        # session_state.existing_project_pagination = navigation_selected_idx
+        session_state.existing_project_pagination = navigation_selected_idx
 
         # NOTE: TO RESET SUB-PAGES AFTER EXIT
         # reset all pages except for the currently selected one

--- a/src/lib/pages/sub_pages/project_page/existing_project_pages/existing_project_dashboard.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project_pages/existing_project_dashboard.py
@@ -49,7 +49,7 @@ from core.utils.form_manager import remove_newline_trailing_whitespace
 from user.user_management import User
 from data_manager.database_manager import init_connection
 from data_manager.dataset_management import NewDataset, query_dataset_list, get_dataset_name_list
-from project.project_management import ProjectDashboardPagination, ProjectPermission, Project, insert_annotated_tasks, query_project_dataset_annotations, show_dataset_chosen_and_annotated_projects
+from project.project_management import ProjectDashboardPagination, ProjectPermission, Project, query_project_dataset_annotations, show_dataset_chosen_and_annotated_projects
 from data_editor.editor_management import Editor
 from data_editor.editor_config import editor_config
 from pages.sub_pages.dataset_page.new_dataset import new_dataset
@@ -68,6 +68,7 @@ def dashboard(RELEASE=True, **kwargs):
 
     label_count_dict = project.get_existing_unique_labels(
         return_counts=True)
+    logger.debug(f"{label_count_dict = }")
     df = project.editor.create_table_of_labels(label_count_dict)
     df.index.name = 'No.'
     df['Percentile (%)'] = df['Percentile (%)'].map("{:.2f}".format)
@@ -175,7 +176,7 @@ def index(RELEASE=True):
         if 'user' not in session_state:
             session_state.user = User(1)
 
-        project: Project = session_state.project
+    project: Project = session_state.project
     # ************************ TEST ************************
 
     if 'project_dashboard_pagination' not in session_state:

--- a/src/lib/pages/sub_pages/project_page/existing_project_pages/existing_project_dashboard.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project_pages/existing_project_dashboard.py
@@ -41,6 +41,7 @@ if str(LIB_PATH) not in sys.path:
 else:
     pass
 
+from annotation.annotation_management import Annotations, NewTask, Task
 from path_desc import chdir_root
 from core.utils.log import logger
 from core.utils.helper import create_dataframe, get_df_row_highlight_color, get_textColor, current_page, non_current_page
@@ -48,7 +49,7 @@ from core.utils.form_manager import remove_newline_trailing_whitespace
 from user.user_management import User
 from data_manager.database_manager import init_connection
 from data_manager.dataset_management import NewDataset, query_dataset_list, get_dataset_name_list
-from project.project_management import ProjectDashboardPagination, ProjectPermission, Project
+from project.project_management import ProjectDashboardPagination, ProjectPermission, Project, insert_annotated_tasks, query_project_dataset_annotations, show_dataset_chosen_and_annotated_projects
 from data_editor.editor_management import Editor
 from data_editor.editor_config import editor_config
 from pages.sub_pages.dataset_page.new_dataset import new_dataset
@@ -59,23 +60,27 @@ chdir_root()  # change to root directory
 
 
 def dashboard(RELEASE=True, **kwargs):
+    project: Project = session_state.project
+
     st.write(f"## **Overview:**")
     # TODO #79 Add dashboard to show types of labels and number of datasets
     # >>>>>>>>>>PANDAS DATAFRAME for LABEL DETAILS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
-    label_count_dict = session_state.project.get_existing_unique_labels(
+    label_count_dict = project.get_existing_unique_labels(
         return_counts=True)
-    df = session_state.project.editor.create_table_of_labels(label_count_dict)
+    df = project.editor.create_table_of_labels(label_count_dict)
     df.index.name = 'No.'
     df['Percentile (%)'] = df['Percentile (%)'].map("{:.2f}".format)
     styler = df.style
 
     # >>>> Annotation table placeholders
+    st.write("### **Annotations**")
     annotation_col1, annotation_col2 = st.columns([3, 0.5])
 
-    annotation_col1.write("### **Annotations**")
     annotation_col1.write(
-        f"#### Total labels : {len(session_state.project.editor.labels_results)}")
+        f"#### Total labels : {len(project.editor.labels_results)}")
+    annotation_col1.write(
+        f"#### Total annotations : {sum(label_count_dict.values())}")
 
     # st.table(styler.set_properties(**{'text-align': 'center'}).set_table_styles(
     #     [dict(selector='th', props=[('text-align', 'center')])]))
@@ -87,8 +92,8 @@ def dashboard(RELEASE=True, **kwargs):
 
     # >>>>>>>>>>PANDAS DATAFRAME for DATASET DETAILS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
     # only show the dataset table if project has selected a dataset
-    if session_state.project.datasets:
-        df = create_dataframe(session_state.project.datasets, column_names=session_state.project.column_names,
+    if project.datasets:
+        df = create_dataframe(project.datasets, column_names=project.column_names,
                               sort=True, sort_by='ID', asc=True, date_time_format=True)
         df_loc = df.loc[:, "ID":"Date/Time"]
 
@@ -99,7 +104,7 @@ def dashboard(RELEASE=True, **kwargs):
 
         dataset_table_col1.write("### **Datasets**")
         dataset_table_col1.write(
-            f"#### Total datasets: {len(session_state.project.datasets)}")
+            f"#### Total datasets: {len(project.datasets)}")
 
         # st.table(styler.set_properties(**{'text-align': 'center'}).set_table_styles(
         #     [dict(selector='th', props=[('text-align', 'center')])]))    # >>>>>>>>>>PANDAS DATAFRAME for DATASET DETAILS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
@@ -133,9 +138,9 @@ def dashboard(RELEASE=True, **kwargs):
               args=(ProjectDashboardPagination.AddExistingDataset,))
 
     # only show this option if already has project_dataset
-    if session_state.project.datasets:
+    if project.datasets:
         project_dataset_chosen = list(
-            session_state.project.dataset_dict.keys())
+            project.dataset_dict.keys())
         st.subheader("Option 4: Select a project dataset to add more images")
         selected_dataset = st.selectbox("Project datasets", options=project_dataset_chosen,
                                         key='selected_dataset')
@@ -169,6 +174,8 @@ def index(RELEASE=True):
             logger.debug("Inside")
         if 'user' not in session_state:
             session_state.user = User(1)
+
+        project: Project = session_state.project
     # ************************ TEST ************************
 
     if 'project_dashboard_pagination' not in session_state:
@@ -185,7 +192,7 @@ def index(RELEASE=True):
             st.stop()
         dataset_dict = get_dataset_name_list(existing_dataset)
         project_dataset_chosen = list(
-            session_state.project.dataset_dict.keys())
+            project.dataset_dict.keys())
         all_datasets = list(dataset_dict.keys())
         for d in project_dataset_chosen:
             # avoid showing selected project datasets to the user to add again
@@ -220,10 +227,10 @@ def index(RELEASE=True):
             help="""Add more dataset to the project. The colored rows in the
             table are the datasets that have already been added to the current project.""")
 
+        st.write("### Dataset chosen:")
         if datasets_to_add:
-            st.write("### Dataset chosen:")
-            for idx, data in enumerate(datasets_to_add):
-                st.write(f"{idx+1}. {data}")
+            annotated_dataset_id2project_id = show_dataset_chosen_and_annotated_projects(
+                datasets_to_add, dataset_dict, project.deployment_type)
         else:
             st.info("No dataset selected")
 
@@ -232,13 +239,15 @@ def index(RELEASE=True):
                 st.warning("No dataset selected to add yet.")
                 st.stop()
 
-            session_state.project.insert_project_dataset(
-                datasets_to_add, dataset_dict)
+            project.insert_project_dataset(
+                datasets_to_add, dataset_dict, annotated_dataset_id2project_id)
+
             logger.info(f"Inserted project datasets '{datasets_to_add}' "
-                        f"for Project {session_state.project.id} into project_dataset table")
+                        f"for Project {project.id} into project_dataset table")
             st.success("Successfully added the selected datasets into project.")
+
             with st.spinner("Refreshing page ..."):
-                session_state.project.refresh_project_details()
+                project.refresh_project_details()
                 session_state.project_dashboard_pagination = ProjectDashboardPagination.ExistingProjectDashboard
             # rerun to show the refreshed details
             st.experimental_rerun()

--- a/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
@@ -214,7 +214,8 @@ def dataset():
                      key='btn_confirm_delete_ds'):
             for id in selected_ids:
                 logger.info(f"Deleting dataset of ID: {id}")
-                Dataset.delete_dataset(id)
+                with st.spinner("Deleting the dataset from local storage and database ..."):
+                    Dataset.delete_dataset(id)
 
             session_state.project.refresh_project_details()
             if not session_state.project.datasets:

--- a/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
@@ -81,6 +81,13 @@ def project():
         if st.button("Confirm deletion?", key='btn_confirm_delete_project'):
             logger.info("Deleting project")
             project_id = session_state.project.id
+            # need to delete project models too
+            project_model_records, _ = query_current_project_models(
+                project_id, return_dict=True)
+            for r in project_model_records:
+                model_id = r['Model ID']
+                Model.delete_model(model_id)
+
             Project.delete_project(project_id)
 
             # reset all session_states except for user and pagination

--- a/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
+++ b/src/lib/pages/sub_pages/project_page/existing_project_pages/settings.py
@@ -47,6 +47,7 @@ from core.utils.log import logger  # logger
 from core.utils.helper import create_dataframe
 from data_manager.data_table_component.data_table import data_table
 from data_manager.dataset_management import Dataset
+from main_page_management import MainPagination
 from training.model_management import Model, query_current_project_models, query_uploaded_models
 from user.user_management import UserRole
 from project.project_management import (ExistingProjectPagination, SettingsPagination,
@@ -82,10 +83,12 @@ def project():
             project_id = session_state.project.id
             Project.delete_project(project_id)
 
-            # reset all session_states
+            # reset all session_states except for user and pagination
+            current_user = session_state.user
             session_state.clear()
+            session_state.user = current_user
 
-            session_state.existing_project_pagination = ExistingProjectPagination.Dashboard
+            session_state.main_pagination = MainPagination.Projects
             st.experimental_rerun()
 
 

--- a/src/lib/pages/sub_pages/project_page/new_project.py
+++ b/src/lib/pages/sub_pages/project_page/new_project.py
@@ -231,6 +231,7 @@ def new_project_entry_page(conn=None):
             annotated_dataset_id2_project_id = show_dataset_chosen_and_annotated_projects(
                 dataset_chosen, dataset_dict, new_project.deployment_type)
         else:
+            annotated_dataset_id2_project_id = None
             st.info("No dataset selected")
 
     # ******************************* Right Column to select dataset *******************************
@@ -287,9 +288,6 @@ def new_project_entry_page(conn=None):
     num_dataset_per_page = 10
     num_dataset_page = math.ceil(len(
         dataset_dict) / num_dataset_per_page)
-
-    print(f"{num_dataset_page = }")
-    print(f"{session_state.new_project_dataset_page = }")
 
     if num_dataset_page > 1:
         if session_state.new_project_dataset_page < num_dataset_page:

--- a/src/lib/pages/sub_pages/project_page/new_project.py
+++ b/src/lib/pages/sub_pages/project_page/new_project.py
@@ -348,9 +348,6 @@ def new_project_entry_page(conn=None):
                     f"Failed to stored **{session_state.new_project.name}** project information in database")
         else:
             st.stop()
-    # TODO #72 Change to 'Update' when 'has_submitted' == True
-    if submit_col2.button("Submit", key="submit"):
-        new_project_submit()
 
     with upload_place.container():
         if st.button("Upload Labeled Dataset", key='btn_upload_labeled_data'):
@@ -359,6 +356,12 @@ def new_project_entry_page(conn=None):
             st.info("""If you choose to upload a labeled dataset, you must first fill
             up the project title and select a template for the deployment type of the
             computer vision task.""")
+
+    # put button at the bottom to allow other things to render first
+    # in case error happens and st.stop() earlier
+    # TODO #72 Change to 'Update' when 'has_submitted' == True
+    if submit_col2.button("Submit", key="submit"):
+        new_project_submit()
 
     # >>>> Removed
     # session_state.new_project.has_submitted = False

--- a/src/lib/pages/sub_pages/project_page/new_project.py
+++ b/src/lib/pages/sub_pages/project_page/new_project.py
@@ -316,25 +316,28 @@ def new_project_entry_page(conn=None):
 
     submit_col1, _, submit_col2 = st.columns([2.5, 0.5, 0.5])
 
-    def new_project_submit(dataset_chosen=dataset_chosen, dataset_dict=dataset_dict, labeled=False):
+    def new_project_submit(labeled=False):
         # if this is True, we will send to New Dataset page for uploading
         if labeled:
             # set this to True to tell new_dataset page about uploading labeled data
-            session_state.is_labeled = labeled
+            session_state.is_labeled = True
             # if uploading labeled dataset, then no need to check the dataset_chosen field
             del context['new_project_dataset_chosen']
         new_project.has_submitted = new_project.check_if_field_empty(
             context, field_placeholder=place, name_key='new_project_name')
 
         if new_project.has_submitted:
-            # TODO #13 Load Task into DB after creation of project
-            # NOTE: dataset_dict is None when user choose to upload labeled dataset,
-            #  this is to skip inserting project dataset that has not been chosen
             if labeled:
-                dataset_dict = None
-                dataset_chosen = None
+                # skip inserting project dataset as the user will
+                #  upload labeled dataset later
+                insert_project_dataset = False
+            else:
+                insert_project_dataset = True
+
             if new_project.initialise_project(
-                    dataset_chosen, dataset_dict, annotated_dataset_id2_project_id):
+                    dataset_chosen, dataset_dict,
+                    insert_project_dataset=insert_project_dataset,
+                    annotated_dataset_info=annotated_dataset_id2_project_id):
                 # Updated with Actual Project ID from DB
                 new_editor.project_id = new_project.id
                 # deployment type now IntEnum

--- a/src/lib/pages/sub_pages/training_page/new_training_subpages/new_training_infodataset.py
+++ b/src/lib/pages/sub_pages/training_page/new_training_subpages/new_training_infodataset.py
@@ -114,15 +114,16 @@ def infodataset():
 
     # >>>> CHECK IF NAME EXISTS CALLBACK >>>>
     def check_if_name_exist(field_placeholder, conn):
-        new_training_name = session_state.new_training_name
+        input_name = session_state.new_training_name.strip()
+        lower_input_name = input_name.lower()
 
         context = {'column_name': 'name',
-                   'value': new_training_name}
+                   'value': lower_input_name}
 
         logger.debug(f"New Training: {context}")
 
-        if new_training_name:
-            if training.name == new_training_name:
+        if lower_input_name:
+            if training.name.lower() == lower_input_name:
                 logger.debug("Not changing name")
                 return
 
@@ -136,7 +137,7 @@ def infodataset():
                 logger.error(f"Training name used. Please enter a new name")
 
             # else:
-            #     training.name = session_state.new_training_name
+            #     training.name = input_name
             #     logger.info(f"Training name fresh and ready to rumble")
 
     with infocol2.container():
@@ -307,7 +308,10 @@ def infodataset():
         else:
             insert_function = training.insert_training_info_dataset
 
-        if training.name == session_state.new_training_name:
+        input_name = session_state.new_training_name.strip()
+        lower_input_name = input_name.lower()
+
+        if training.name.lower() == lower_input_name:
             # no need to check whether the name exists if the user is using the same
             # existing submitted name
             logger.info("Existing training name is not changed")
@@ -320,7 +324,8 @@ def infodataset():
             insert=insert_function,
             update=training.update_training_info_dataset,
             context={
-                'new_training_name': session_state.new_training_name,
+                # check the lowercase input name, but insert user input name later
+                'new_training_name': lower_input_name,
                 'new_training_dataset_chosen': dataset_chosen
             },
             name_key=name_key
@@ -338,7 +343,8 @@ def infodataset():
             # Training Name,Desc, Dataset chosen, Partition Size
             training.dataset_chosen = dataset_chosen
             if new_training_infodataset_submission_dict.insert(
-                    session_state.new_training_name,
+                    # insert the user input one, not the lowercase one
+                    input_name,
                     description, partition_ratio):
                 session_state.new_training_pagination = NewTrainingPagination.Model
                 # must set this to tell the models_page.py to move to stay in its page
@@ -354,7 +360,8 @@ def infodataset():
             if new_training_infodataset_submission_dict.update(
                     partition_ratio, dataset_chosen,
                     session_state.project.dataset_dict,
-                    name=session_state.new_training_name,
+                    # update with the user input one, not the lowercase one
+                    name=input_name,
                     desc=description):
                 # session_state.new_training_pagination = NewTrainingPagination.Model
                 # # must set this to tell the models_page.py to move to stay in its page

--- a/src/lib/pages/sub_pages/training_page/run_training_page.py
+++ b/src/lib/pages/sub_pages/training_page/run_training_page.py
@@ -51,7 +51,7 @@ import tensorflow as tf
 # >>>> User-defined Modules >>>>
 from core.utils.log import logger
 from machine_learning.trainer import Trainer
-from machine_learning.command_utils import kill_process, run_tensorboard
+from machine_learning.command_utils import kill_process, kill_tensorboard, run_tensorboard
 from machine_learning.visuals import pretty_format_param
 from project.project_management import Project
 from training.training_management import NewTrainingPagination, Training, TrainingPagination

--- a/src/lib/pages/sub_pages/training_page/run_training_page.py
+++ b/src/lib/pages/sub_pages/training_page/run_training_page.py
@@ -130,9 +130,32 @@ def index(RELEASE=True):
                 nonlocal trainer
                 trainer = session_state.trainer
 
+    def show_edit_training_btn():
+        def back_train_info_page():
+            # reset it in case the user decided to change any info
+            reset_trainer()
+            session_state.new_training_pagination = NewTrainingPagination.InfoDataset
+
+        st.button('⚙️ Edit Training Info', key='btn_edit_train_info',
+                  on_click=back_train_info_page)
+
+    def show_edit_model_btn():
+        def back_model_page_cb():
+            reset_trainer()
+            session_state.new_training_pagination = NewTrainingPagination.Model
+
+        st.button('⚙️ Edit Model Info', key='btn_edit_model_info',
+                  on_click=back_model_page_cb)
+
     st.markdown("### Training Info:")
 
     dataset_chosen = training.dataset_chosen
+    if not dataset_chosen:
+        st.warning("""This training session **does not have any training dataset** 
+        chosen yet. Please proceed to the training info page to select it.""")
+        show_edit_training_btn()
+        st.stop()
+
     if len(dataset_chosen) == 1:
         dataset_chosen_str = dataset_chosen[0]
     else:
@@ -148,9 +171,9 @@ def index(RELEASE=True):
     **Partition Ratio**: training : validation : test -> 
     {partition_ratio['train']} : {partition_ratio['eval']} : {partition_ratio['test']}  \n
     **Partition Size**: training : validation : test -> 
-    {session_state.new_training.partition_size['train']} :
-    {session_state.new_training.partition_size['eval']} :
-    {session_state.new_training.partition_size['test']}  \n
+    {training.partition_size['train']} :
+    {training.partition_size['eval']} :
+    {training.partition_size['test']}  \n
     **Selected Model Name**: {training.attached_model.name}  \n
     **Model Name**: {training.training_model.name}  \n
     **Model Description**: {training.training_model.desc}
@@ -158,22 +181,11 @@ def index(RELEASE=True):
 
     train_info_btn, model_info_btn, _ = st.columns([2, 1, 4])
 
-    def back_train_info_page():
-        # reset it in case the user decided to change any info
-        reset_trainer()
-        session_state.new_training_pagination = NewTrainingPagination.InfoDataset
-
     with train_info_btn:
-        st.button('⚙️ Edit Training Info', key='btn_edit_train_info',
-                  on_click=back_train_info_page)
-
-    def back_model_page():
-        reset_trainer()
-        session_state.new_training_pagination = NewTrainingPagination.Model
+        show_edit_training_btn()
 
     with model_info_btn:
-        st.button('⚙️ Edit Model Info', key='btn_edit_model_info',
-                  on_click=back_model_page)
+        show_edit_model_btn()
 
     if training.is_started:
         st.warning("✏️ **NOTE**: Only edit the model selection"
@@ -188,12 +200,12 @@ def index(RELEASE=True):
         st.markdown('### Training Config:')
         st.info(config_info)
 
-        def back_config_page():
+        def back_config_page_cb():
             reset_trainer()
             session_state.new_training_pagination = NewTrainingPagination.TrainingConfig
 
         st.button('⚙️ Edit Training Config', key='btn_edit_config',
-                  on_click=back_config_page)
+                  on_click=back_config_page_cb)
 
     with aug_config_col:
         # TODO: confirm that this works for image classification and segmentation
@@ -206,12 +218,12 @@ def index(RELEASE=True):
         else:
             st.info("No augmentation config selected.")
 
-        def back_aug_config_page():
+        def back_aug_config_page_cb():
             reset_trainer()
             session_state.new_training_pagination = NewTrainingPagination.AugmentationConfig
 
         st.button('⚙️ Edit Augmentation Config', key='btn_edit_aug_config',
-                  on_click=back_aug_config_page)
+                  on_click=back_aug_config_page_cb)
 
     if training.is_started:
         st.warning(
@@ -510,6 +522,9 @@ def index(RELEASE=True):
             is_resume = False if retrain else True
             with retrain_place.container():
                 start_training_callback(is_resume)
+
+    if session_state.get('trainer'):
+        st.write(session_state.trainer)
 
     # st.write("vars(training)")
     # st.write(vars(training))

--- a/src/lib/pages/sub_pages/training_page/run_training_page.py
+++ b/src/lib/pages/sub_pages/training_page/run_training_page.py
@@ -498,17 +498,16 @@ def index(RELEASE=True):
                     st.warning("""**WARNING**: You don't have access to GPU. Inference time
                     will be slower depending on the capability of your CPU and system.""")
 
-                with st.spinner("Running evaluation ..."):
-                    try:
-                        trainer.evaluate()
-                    except Exception as e:
-                        if os.getenv('DEBUG', '1') == '1':
-                            st.exception(e)
-                        st.error(
-                            "Some error has occurred. Please try checking the terminal "
-                            "output for the error. Or just try pressing *'R'* to refresh the page. "
-                            "If it still doesn't work, please try training the model again.")
-                        logger.error(f"Error evaluating: {e}")
+                try:
+                    trainer.evaluate()
+                except Exception as e:
+                    if os.getenv('DEBUG', '1') == '1':
+                        st.exception(e)
+                    st.error(
+                        "Some error has occurred. Please try checking the terminal "
+                        "output for the error. Or just try pressing *'R'* to refresh the page. "
+                        "If it still doesn't work, please try training the model again.")
+                    logger.error(f"Error evaluating: {e}")
             else:
                 logger.info(f"Model {training.training_model_id} "
                             "is not exported yet. Skipping evaluation")
@@ -522,9 +521,6 @@ def index(RELEASE=True):
             is_resume = False if retrain else True
             with retrain_place.container():
                 start_training_callback(is_resume)
-
-    if session_state.get('trainer'):
-        st.write(session_state.trainer)
 
     # st.write("vars(training)")
     # st.write(vars(training))

--- a/src/lib/pages/sub_pages/training_page/run_training_page.py
+++ b/src/lib/pages/sub_pages/training_page/run_training_page.py
@@ -260,7 +260,8 @@ def index(RELEASE=True):
 
         with btn_stop_col:
             st.button("⛔ Stop Training", key='btn_stop_training',
-                      on_click=stop_run_training)
+                      on_click=stop_run_training,
+                      help="This takes a short while to stop the training")
             st.warning('✏️ **NOTE**: If you click this button, '
                        'the latest progress might not be saved.')
 

--- a/src/lib/project/project_management.py
+++ b/src/lib/project/project_management.py
@@ -362,7 +362,8 @@ class BaseProject:
     def insert_project_dataset(
             self, dataset_chosen: List[str],
             dataset_dict: Dict[str, NamedTuple],
-            annotated_dataset_info: Dict[int, int] = None):
+            annotated_dataset_info: Dict[int, int] = None,
+            is_new_project: bool = False):
         insert_project_dataset_SQL = """
                                         INSERT INTO public.project_dataset (
                                             project_id,
@@ -389,11 +390,13 @@ class BaseProject:
                 dataset_name, dataset_id,
                 annotated_dataset_info=annotated_dataset_info)
 
-        if isinstance(session_state.get('project'), Project):
+        # update editor_config only if annotated_dataset_info is supplied
+        # to an existing project
+        if annotated_dataset_info and isinstance(session_state.get('project'), Project):
             logger.info(
                 "Updating Project's EditorConfig based on the annotations")
             session_state.project.update_editor_config(
-                refresh_project=True)
+                is_new_project, refresh_project=True)
 
 
 class Project(BaseProject):

--- a/src/lib/project/project_management.py
+++ b/src/lib/project/project_management.py
@@ -966,9 +966,9 @@ class Project(BaseProject):
             # the existing_config_labels only contains the default
             #  editor_config template labels, so we get the unwanted
             #  default_labels came with the defaults,
-            #  but keep the ones from new_labels
+            #  but keep the ones from existing labels
             unwanted_labels = set(existing_config_labels).difference(
-                new_labels)
+                existing_annotated_labels)
 
             if unwanted_labels:
                 for label in unwanted_labels:

--- a/src/lib/project/project_management.py
+++ b/src/lib/project/project_management.py
@@ -644,9 +644,9 @@ class Project(BaseProject):
             return json_path, dataset_names
         return json_path
 
-    def get_existing_unique_labels(self,
-                                   return_counts: bool = False) -> Union[List[str],
-                                                                         Dict[str, int]]:
+    def get_existing_unique_labels(
+            self, return_counts: bool = False,
+            for_training_id: int = 0) -> Union[List[str], Dict[str, int]]:
         """Extracting the unique label names used in existing annotations.
         Note that segmentation task will add a 'background' class later when building
         mask images for training.
@@ -654,6 +654,8 @@ class Project(BaseProject):
         Args:
             return_counts (bool, optional): If True, returns Dict with counts as values. 
                 Defaults to False.
+            for_training_id (int, optional): If `for_training_id` is provided,
+                then only the annotations associated with the `training_id` is checked.
 
         Returns:
             Union[List[str], Dict[str, int]]: Returns List of unique label names, 
@@ -676,7 +678,8 @@ class Project(BaseProject):
         ```
         """
         # `all_annots` is a list of dictionaries for each annotation
-        all_annots, col_names = self.query_annotations(return_dict=True)
+        all_annots, col_names = self.query_annotations(
+            for_training_id=for_training_id, return_dict=True)
         if not all_annots:
             # there is no existing annotation
             logger.error(f"No existing annotations for Project {self.id}")

--- a/src/lib/training/model_management.py
+++ b/src/lib/training/model_management.py
@@ -61,6 +61,7 @@ from data_manager.database_manager import (db_fetchall, db_fetchone,
                                            db_no_fetch, init_connection)
 from deployment.deployment_management import (COMPUTER_VISION_LIST, Deployment,
                                               DeploymentType)
+from machine_learning.command_utils import rename_folder
 from machine_learning.utils import load_trained_keras_model, modify_trained_model_layers
 from machine_learning.visuals import prettify_db_metrics
 
@@ -1033,20 +1034,11 @@ class BaseModel:
             model_type=self.model_type,
             new_model_flag=True)
 
-        if prev_model_path.exists():
+        if prev_model_path.exists() and prev_model_path != model_path:
             # rename the existing directory to the new name
             logger.info("Renaming existing model path to new path:"
                         f"{prev_model_path} -> {model_path}")
-            try:
-                os.rename(prev_model_path, model_path)
-            except Exception as e:
-                logger.error(
-                    f"Error renaming model path, probably due to access error: {e}")
-                st.error(
-                    f"""Error renaming model path, probably due to access error. Please
-                    make sure there is nothing accessing the previous model path at:
-                    {prev_model_path}, then press *'R'* to refresh current page.""")
-                st.stop()
+            rename_folder(prev_model_path, model_path)
         logger.info(f"New Updated Model Path: {model_path}")
 
         # update new name if no error

--- a/src/lib/training/model_management.py
+++ b/src/lib/training/model_management.py
@@ -1368,7 +1368,7 @@ class Model(BaseModel):
             return False
 
     @staticmethod
-    def delete_model(model_id: int = None):
+    def delete_model(model_id: int):
         """Delete model directories, delete model row from 'models' table, and
         reset the training_model's info at 'training' table"""
         # need model_id to get the project_model path from DB to delete the directories
@@ -1593,7 +1593,8 @@ def query_current_project_models(
     `prettify_metrics` is to prettify the Metrics into one line especially for displaying
     with a table.
 
-    `trained` = True means `is_started` = True in the 'training' table.
+    `trained` = True means `is_started` = True in the 'training' table. Note that if
+    `trained` = False, both `is_started` (True or False) will also be queried.
     """
     ID_string = "id" if for_data_table else "ID"
 

--- a/src/lib/training/training_management.py
+++ b/src/lib/training/training_management.py
@@ -60,6 +60,7 @@ from core.utils.log import logger  # logger
 from data_manager.database_manager import (db_fetchall, db_fetchone,
                                            db_no_fetch, init_connection)
 from deployment.deployment_management import Deployment, DeploymentType
+from machine_learning.command_utils import rename_folder
 from project.project_management import Project
 from training.model_management import BaseModel, Model, ModelType, NewModel
 from training.utils import get_segmentation_model_func2params, get_segmentation_model_name2func
@@ -421,7 +422,7 @@ class BaseTraining:
 
                 logger.info("Renaming existing training path to new path: "
                             f"{current_training_path} -> {new_path}")
-                os.rename(current_training_path, new_path)
+                rename_folder(current_training_path, new_path)
             self.name = name
 
         if desc is not None:

--- a/src/lib/training/training_management.py
+++ b/src/lib/training/training_management.py
@@ -309,6 +309,7 @@ class BaseTraining:
             partition_size['train'] = ceil(num_train_eval * (partition_ratio['train']) / (
                 partition_ratio['train'] + partition_ratio['eval']))
             partition_size['eval'] = num_train_eval - partition_size['train']
+            logger.debug(f"{partition_size = }")
             return partition_size
         else:
             logger.warning(

--- a/src/lib/training/training_management.py
+++ b/src/lib/training/training_management.py
@@ -411,19 +411,21 @@ class BaseTraining:
         Returns:
             bool: True is successful, otherwise False
         """
-        # only need to rename the path if it's new name
-        if name is not None and name != self.name:
-            current_training_path = self.get_training_path(
-                self.project_path, self.name)
-            if current_training_path.exists():
-                # rename the existing training directory if it already exists
-                new_path = self.get_training_path(
-                    self.project_path, name)
-
-                logger.info("Renaming existing training path to new path: "
-                            f"{current_training_path} -> {new_path}")
-                rename_folder(current_training_path, new_path)
+        if name is not None:
             self.name = name
+
+            # only need to rename the path if it's new name
+            if name != self.name:
+                current_training_path = self.get_training_path(
+                    self.project_path, self.name)
+                if current_training_path.exists():
+                    # rename the existing training directory if it already exists
+                    new_path = self.get_training_path(
+                        self.project_path, name)
+
+                    logger.info("Renaming existing training path to new path: "
+                                f"{current_training_path} -> {new_path}")
+                    rename_folder(current_training_path, new_path)
 
         if desc is not None:
             self.desc = desc
@@ -890,6 +892,7 @@ class NewTraining(BaseTraining):
     #     return self.id
 
 # TODO #133 Add New Training Reset
+
 
     @staticmethod
     def reset_new_training_page():
@@ -1385,6 +1388,7 @@ class Training(BaseTraining):
     #             f"Failed to stored **{self.name}** training information in database")
     #         return False
 # NOTE ******************* DEPRECATED *********************************************
+
 
     @staticmethod
     def progress_preprocessing(all_project_training: Union[List[NamedTuple], List[Dict]],

--- a/src/lib/training/training_management.py
+++ b/src/lib/training/training_management.py
@@ -336,6 +336,8 @@ class BaseTraining:
         else:
             logger.info(
                 f"There are no change in the dataset chosen {self.dataset_chosen}")
+        # update self
+        self.dataset_chosen = submitted_dataset_chosen.copy()
 
     def remove_training_dataset(self, removed_dataset: List, dataset_dict: Dict):
         """Remove dataset from training_dataset table in the Database
@@ -546,14 +548,15 @@ class BaseTraining:
             assert partition_ratio['eval'] > 0.0, "Dataset Evaluation Ratio needs to be > 0"
 
             self.partition_ratio = partition_ratio.copy()
+            # update dataset_chosen first before calculate partition size
+            self.update_dataset_chosen(submitted_dataset_chosen=submitted_dataset_chosen,
+                                       dataset_dict=dataset_dict)
+
             self.partition_size = self.calc_dataset_partition_size(
                 partition_ratio, self.dataset_chosen,
                 session_state.project.dataset_dict)
 
             self.update_training_info(name, desc)
-
-            self.update_dataset_chosen(submitted_dataset_chosen=submitted_dataset_chosen,
-                                       dataset_dict=dataset_dict)
 
             return True
 


### PR DESCRIPTION
Allow user to choose to use existing annotations in two situations:
1. When creating a new project,
2. Or when adding existing dataset to the current project

UPDATE:
- Fix a lot of stuff related to the new_dataset.py for adding data to existing dataset, either labeled or not labeled.
- Feat: generate new names for images to avoid duplicated names
- Fix: training for classification/segmentation Trainer.create_tf_dataset() to shuffle both X_train and y_train together
- Refactor inference functions into deployment.utils for easier reuse in evaluation and deployment